### PR TITLE
Bumps go version to 1.21 (latest stable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM golang:1.16.0-stretch AS builder
+FROM golang:1.21.3-bookworm AS builder
 
 LABEL maintainer="ONF <omec-dev@opennetworking.org>"
 
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get -y install vim
 
 RUN cd $GOPATH/src && mkdir -p metricfunc
 COPY . $GOPATH/src/metricfunc
-RUN cd $GOPATH/src/metricfunc/cmd/metricfunc && CGO_ENABLED=0 go build
+RUN cd $GOPATH/src/metricfunc/cmd/metricfunc && CGO_ENABLED=0 go build -mod=mod
 
 FROM alpine:3.16 as metricfunc
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DOCKER_TARGETS           ?= metricfunc
 docker-build:
 	@go mod vendor
 	for target in $(DOCKER_TARGETS); do \
-		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker buildx build --platform linux/amd64  $(DOCKER_BUILD_ARGS) \
+		DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build $(DOCKER_BUILD_ARGS) \
 			--target $$target \
 			--tag ${DOCKER_REGISTRY}${DOCKER_REPOSITORY}$$target:${DOCKER_TAG} \
 			--build-arg org_label_schema_version="${DOCKER_VERSION}" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omec-project/metricfunc
 
-go 1.18
+go 1.21
 
 replace github.com/omec-project/metricfunc => ./
 

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=


### PR DESCRIPTION
This PR bumps the go version to 1.21 which is the latest stable release. 

The update is accomplished by running following commands:
```
go mod edit -go=1.21
go mod tidy
```

Reference: https://tip.golang.org/doc/go1.21