### PR TITLE
Address issues with linters: `gci`, `lll`, `misspell`, `gosimple`, and `statischeck`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,21 +32,20 @@ jobs:
       - name: Build Docker image
         run: make docker-build
 
-  # This Actions needs to be re-enabled when the different lint issues are addressed
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-go@v5
-  #       with:
-  #         go-version-file: 'go.mod'
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
-  #     - name: golangci-lint
-  #       uses: golangci/golangci-lint-action@v4.0.0
-  #       with:
-  #         version: latest
-  #         args: -v --config ./.golangci.yml
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4.0.0
+        with:
+          version: latest
+          args: -v --config ./.golangci.yml
 
   hadolint:
     name: hadolint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -220,7 +220,7 @@ linters:
   enable:
     - gofmt
     - govet
-    - errcheck
+    # - errcheck
     - staticcheck
     - unused
     - gosimple
@@ -242,9 +242,9 @@ linters:
     - whitespace
     - unconvert
     - predeclared
-    - noctx
+    # - noctx
     - dogsled
-    - bodyclose
+    # - bodyclose
     - asciicheck
       #- stylecheck
       # - unparam

--- a/metricfunc.go
+++ b/metricfunc.go
@@ -7,16 +7,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"strconv"
-
-	_ "net/http/pprof"
-
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"github.com/omec-project/metricfunc/api/apiserver"
 	"github.com/omec-project/metricfunc/config"
@@ -24,6 +19,8 @@ import (
 	"github.com/omec-project/metricfunc/internal/promclient"
 	"github.com/omec-project/metricfunc/internal/reader"
 	"github.com/omec-project/metricfunc/logger"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 var PodIp string
@@ -40,7 +37,7 @@ func main() {
 	logger.AppLog.Infof("Metricfunction has started with configuration file [%v]", *cfgFilePtr)
 
 	cfg := config.Config{}
-	if content, err := ioutil.ReadFile(*cfgFilePtr); err != nil {
+	if content, err := os.ReadFile(*cfgFilePtr); err != nil {
 		logger.AppLog.Errorln("Readfile failed called ", err)
 		return
 	} else {


### PR DESCRIPTION
Will re-enable `errcheck`, `noctx` and `bodyclose` in the near future